### PR TITLE
Add explanation for rest vpc resources fields

### DIFF
--- a/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
+++ b/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
@@ -3098,35 +3098,35 @@
       "where": "条件查询，表示查询符合该条件的资源。"
     },
     "NestedVirtualPrivateCloudFloatingIp": {
-      "external_ip": "",
+      "external_ip": "分配的 IP 地址",
       "id": "唯一标识"
     },
     "NestedVirtualPrivateCloudNatGateway": {
-      "external_ip": "",
+      "external_ip": "转换地址",
       "id": "唯一标识",
       "name": "名称"
     },
     "NestedVirtualPrivateCloudRouterGateway": {
-      "external_ip": "",
+      "external_ip": "外部接口",
       "id": "唯一标识",
       "name": "名称"
     },
     "VirtualPrivateCloudExternalSubnet": {
-      "cidr": "",
-      "description": "",
+      "cidr": "CIDR 块",
+      "description": "描述",
       "entityAsyncStatus": "",
-      "floating_ip_cidr": "",
-      "floating_ips": "",
-      "gateway": "",
-      "id": "",
-      "local_id": "",
-      "name": "",
-      "nat_gateway_cidr": "",
-      "nat_gateways": "",
-      "router_gateway_cidr": "",
-      "router_gateways": "",
-      "vlan": "",
-      "vpc": ""
+      "floating_ip_cidr": "从 CIDR 块中指定的浮动 IP 地址块",
+      "floating_ips": "关联浮动 IP 集合",
+      "gateway": "默认网关地址",
+      "id": "资源的唯一标识",
+      "local_id": "资源的 UUID",
+      "name": "名称",
+      "nat_gateway_cidr": "从 CIDR 块中指定的 NAT 网关地址块",
+      "nat_gateways": "关联 NAT 网关集合",
+      "router_gateway_cidr": "从 CIDR 块中指定的路由网关地址块",
+      "router_gateways": "关联路由网关集合",
+      "vlan": "虚拟机网络",
+      "vpc": "所属 VPC"
     },
     "VirtualPrivateCloudExternalSubnetOrderByInput": {
       "enum": "按照指定方式排列放回数据"

--- a/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
+++ b/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
@@ -2505,7 +2505,7 @@
       "vpc": ""
     },
     "VirtualPrivateCloudSecurityPolicyMode": {
-      "enum": ""
+      "enum": "* MONITOR: 不生效\n* WORK: 立即生效"
     },
     "VirtualPrivateCloudNicSnapshotWhereInput": {
       "AND": "符合所有的筛选条件",
@@ -2957,29 +2957,29 @@
       "name": "名称"
     },
     "NestedVirtualPrivateCloudSecurityPolicyApply": {
-      "communicable": "",
-      "security_group": "",
-      "security_group_id": ""
+      "communicable": "策略对象是否可以互相通信",
+      "security_group": "VPC 安全组",
+      "security_group_id": "VPC 安全组 id"
     },
     "VirtualPrivateCloudNetworkPolicyRulePortProtocol": {
-      "enum": ""
+      "enum": "* TCP: TCP 协议\n* UDP: UDP 协议\n* ICMP: ICMP 协议"
     },
     "NestedVirtualPrivateCloudNetworkPolicyRulePort": {
-      "port": "",
-      "protocol": ""
+      "port": "端口号",
+      "protocol": "协议类型"
     },
     "VirtualPrivateCloudNetworkPolicyRuleType": {
-      "enum": ""
+      "enum": "* ALL: 流量全允许\n* IP_BLOCK: IP 地址类型白名单\n* SELECTOR: 标签类型白名单\n* SECURITY_GROUP: 安全组类型白名单"
     },
     "NestedVirtualPrivateCloudNetworkPolicyRule": {
-      "except_ip_block": "",
-      "ip_block": "",
-      "ports": "",
-      "security_group": "",
-      "security_group_id": "",
-      "selector": "",
-      "selector_ids": "",
-      "type": ""
+      "except_ip_block": "排除 IP 地址，白名单类型为 IP 地址时配置生效",
+      "ip_block": "IP 地址，白名单类型为 IP 地址时配置生效",
+      "ports": "协议配置",
+      "security_group": "安全组",
+      "security_group_id": "VPC 安全组 id，白名单类型为安全组时配置生效",
+      "selector": "标签",
+      "selector_ids": "标签 id 集合，白名单类型为标签时配置生效",
+      "type": "白名单类型"
     },
     "NfsInode": {
       "assigned_size": "分配容量(字节)",
@@ -10338,45 +10338,45 @@
       "type_not_in": ""
     },
     "VirtualPrivateCloudSecurityPolicy": {
-      "apply_to": "",
-      "description": "",
-      "egress": "",
+      "apply_to": "策略对象集合",
+      "description": "描述",
+      "egress": "出流量白名单配置",
       "entityAsyncStatus": "",
-      "id": "",
-      "ingress": "",
-      "local_id": "",
-      "name": "",
-      "policy_mode": "",
-      "vpc": ""
+      "id": "资源的唯一标识",
+      "ingress": "入流量白名单配置",
+      "local_id": "资源的 UUID",
+      "name": "名称",
+      "policy_mode": "策略生效模式",
+      "vpc": "所属 VPC"
     },
     "WithTask_VirtualPrivateCloudSecurityPolicy_": {
       "task_id": "异步任务 id。",
       "data": "资源"
     },
     "VirtualPrivateCloudSecurityPolicyApplyInput": {
-      "security_group_id": "",
-      "communicable": ""
+      "security_group_id": "VPC 安全组 id",
+      "communicable": "策略对象是否可以互相通信"
     },
     "VirtualPrivateCloudNetworkPolicyRulePortInput": {
-      "protocol": "",
-      "port": ""
+      "protocol": "协议类型",
+      "port": "端口号"
     },
     "VirtualPrivateCloudNetworkPolicyRuleInput": {
-      "type": "",
-      "selector_ids": "",
-      "security_group_id": "",
-      "ports": "",
-      "ip_block": "",
-      "except_ip_block": ""
+      "type": "白名单类型",
+      "selector_ids": "标签 id 集合，白名单类型为标签时配置生效",
+      "security_group_id": "VPC 安全组 id，白名单类型为安全组时配置生效",
+      "ports": "协议配置",
+      "ip_block": "IP 地址，白名单类型为 IP 地址时配置生效",
+      "except_ip_block": "排除 IP 地址，白名单类型为 IP 地址时配置生效"
     },
     "VirtualPrivateCloudSecurityPolicyCreateParams": {
-      "egress": "",
-      "ingress": "",
-      "apply_to": "",
-      "policy_mode": "",
-      "vpc_id": "",
-      "description": "",
-      "name": ""
+      "egress": "出流量白名单配置",
+      "ingress": "入流量白名单配置",
+      "apply_to": "策略对象集合",
+      "policy_mode": "策略生效模式",
+      "vpc_id": "所属 VPC 的 id",
+      "description": "描述",
+      "name": "名称"
     },
     "DeleteVirtualPrivateCloudSecurityPolicy": {
       "id": "资源 id"
@@ -10386,19 +10386,19 @@
       "data": "资源"
     },
     "VirtualPrivateCloudSecurityPolicyDeleteParams": {
-      "where": ""
+      "where": "用于删除指定 VPC 安全安全策略的查询条件"
     },
     "VirtualPrivateCloudSecurityPolicyUpdateParams": {
-      "ingress": "",
-      "egress": "",
-      "apply_to": "",
-      "policy_mode": "",
-      "description": "",
-      "name": ""
+      "ingress": "入流量白名单配置",
+      "egress": "出流量白名单配置",
+      "apply_to": "策略对象集合",
+      "policy_mode": "策略生效模式",
+      "description": "描述",
+      "name": "名称"
     },
     "VirtualPrivateCloudSecurityPolicyUpdateBody": {
-      "data": "",
-      "where": ""
+      "data": "用于更新指定 VPC 安全策略的数据",
+      "where": "用于删除指定 VPC 安全安全策略的查询条件"
     },
     "NestedVpcSubnetIpPooType": {
       "end": "子网的 IP 地址池的结束 IP",

--- a/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
+++ b/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
@@ -3022,12 +3022,12 @@
       "vpc_nic": ""
     },
     "VirtualPrivateCloudClusterBinding": {
-      "cluster": "",
+      "cluster": "关联集群",
       "entityAsyncStatus": "",
-      "id": "",
-      "mtu": "",
-      "vds": "",
-      "vlan_id": ""
+      "id": "资源的唯一标识",
+      "mtu": "VPC 系统网络的 MTU",
+      "vds": "关联虚拟分布式交换机",
+      "vlan_id": "VLAN 的唯一标识"
     },
     "VirtualPrivateCloudClusterBindingOrderByInput": {
       "enum": "按照指定方式排列放回数据"

--- a/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
+++ b/cloudtower-api-doc/swagger/locales/zh/4.2.0.json
@@ -2563,8 +2563,8 @@
     },
     "NestedLabel": {
       "id": "唯一标识",
-      "key": "",
-      "value": ""
+      "key": "标签的 key",
+      "value": "标签的 value"
     },
     "Vm": {
       "clock_offset": "虚拟机时钟",
@@ -2907,40 +2907,40 @@
       "where": ""
     },
     "NestedVirtualPrivateCloudLabelGroup": {
-      "labels": ""
+      "labels": "关联标签集合"
     },
     "VirtualPrivateCloudSecurityGroup": {
-      "default_for_vpc": "",
-      "description": "",
+      "default_for_vpc": "是否为 VPC 的默认安全组",
+      "description": "描述",
       "entityAsyncStatus": "",
-      "id": "",
-      "label_groups": "",
-      "local_id": "",
-      "name": "",
-      "vms": "",
-      "vpc": ""
+      "id": "资源的唯一标识",
+      "label_groups": "标签组",
+      "local_id": "资源的 UUID",
+      "name": "名称",
+      "vms": "关联虚拟机集合",
+      "vpc": "所属 VPC"
     },
     "WithTask_VirtualPrivateCloudSecurityGroup_": {
       "task_id": "异步任务 id。",
       "data": "资源"
     },
     "LabelGroup": {
-      "label_ids": ""
+      "label_ids": "关联标签 id 集合"
     },
     "VirtualPrivateCloudSecurityGroupCreationParams": {
-      "vm_ids": "",
-      "label_groups": "",
-      "vpc_id": "",
-      "description": "",
-      "name": ""
+      "vm_ids": "关联虚拟机 id 集合",
+      "label_groups": "标签组",
+      "vpc_id": "所属 VPC 的 id",
+      "description": "描述",
+      "name": "名称"
     },
     "VirtualPrivateCloudSecurityGroupUpdationParams": {
-      "data.vm_ids": "",
-      "data.label_groups": "",
-      "data.description": "",
-      "data.name": "",
-      "data": "",
-      "where": ""
+      "data.vm_ids": "关联虚拟机 id 集合",
+      "data.label_groups": "标签组",
+      "data.description": "描述",
+      "data.name": "名称",
+      "data": "用于更新指定 VPC 安全组的数据",
+      "where": "用于更新指定 VPC 安全组的查询条件"
     },
     "DeleteVirtualPrivateCloudSecurityGroup": {
       "id": "资源 id"
@@ -2950,7 +2950,7 @@
       "data": "资源"
     },
     "VirtualPrivateCloudSecurityGroupDeletionParams": {
-      "where": ""
+      "where": "用于删除指定 VPC 安全组的查询条件"
     },
     "NestedVirtualPrivateCloudSecurityGroup": {
       "id": "唯一标识",


### PR DESCRIPTION
## 新增 vpc 安全组、vpc 安全策略、vpc 关联集群、外部子网资源字段说明

## 自测截图
- vpc 安全组 
<img width="1439" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/da78fd8c-e02b-432b-be3a-2271d1c1f71a">
<img width="1433" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/8d50ef17-bf14-4b8a-aa34-f636f13934c6">
<img width="1432" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/3939b53c-f2d1-4d8c-b3e5-08c252e2ab56">
- vpc 安全策略
<img width="1435" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/97b77ac7-ddcb-4e19-bb5f-70d64a4e3efd">
<img width="1438" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/26e930fc-7a1e-4b37-96bc-98d549e1f3c4">

- 关联集群 
<img width="1434" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/75e2a6ff-fc3a-4199-a3e1-fe95dd22e7ab">

- 外部子网
<img width="1433" alt="image" src="https://github.com/smartxworks/cloudtower-api-doc-tauri/assets/134247770/e059666e-8a36-455a-b5db-cc4cdf99d6f5">
